### PR TITLE
Allow custom XGBoost versions in XGBOOST_BUILD_VERSION

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,10 +4,11 @@ using BinDeps
 
 xgboost = library_dependency("xgboost", aliases = ["libxgboost.so"])
 
-if haskey(ENV, "XGBOOST_BUILD_VERSION") && ENV["XGBOOST_BUILD_VERSION"] == "master"
-    libcheckout = `git checkout master`
-    onload = "global const build_version = \"master\""
-    info("Using the latest master version of the XGBoost library")
+if haskey(ENV, "XGBOOST_BUILD_VERSION")
+    build_version = ENV["XGBOOST_BUILD_VERSION"]
+    libcheckout = `git checkout $(build_version)`
+    onload = "global const build_version = \"$(build_version)\""
+    info("Using the $(build_version) version of the XGBoost library")
 else
     libcheckout = `git checkout v0.60`
     onload = "global const build_version = \"0.60\""


### PR DESCRIPTION
Currently XGBoost.jl allow building either "master" or known stable tags (v0.6, v0.8) of XGBoost git repository. This change removes that restriction and make it possible to build with any git tag, branch or  commitsh. 

This is required to workaround some of XGBoost.jl package build issues occurred due to [some refactoring done in XGBoost git repository](https://github.com/dmlc/xgboost/commit/207f0587111a951f5cd6c609ade001587f242bd1)

With this change we can build XGBoost.jl with last known good git commit of XGBoost.

> 16:10:10 INFO: Changing directory to /home/roames/.julia/declarative/79d280142be79f672a1b604f9c10050d/v0.6/XGBoost/deps/src/xgboost
> 16:10:10 Already on 'master'
> 16:10:10 Your branch is up to date with 'origin/master'.
> 16:10:10 INFO: Changing directory to /home/roames/.julia/declarative/79d280142be79f672a1b604f9c10050d/v0.6/XGBoost/deps/src/xgboost
> 16:10:10 bash: build.sh: No such file or directory
> 16:10:10 ======================[ ERROR: XGBoost ]===================
> 16:10:10 
> 16:10:10 LoadError: failed process: Process(`bash build.sh`, ProcessExited(127)) [127]
> 16:10:10 while loading /home/roames/.julia/declarative/79d280142be79f672a1b604f9c10050d/v0.6/XGBoost/deps/build.jl, in expression starting on line 36
> 16:10:10 
> 16:10:10 ================================================
